### PR TITLE
画像投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,5 @@ end
 
 gem 'devise'
 gem 'pry-rails'
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.11.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     listen (3.1.5)
@@ -103,6 +106,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -163,6 +167,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -228,8 +234,10 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 3.11)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,6 +19,6 @@ class MessagesController < ApplicationController
   private
 
   def message_params
-    params.require(:message).permit(:content).merge(user_id: current_user.id)
+    params.require(:message).permit(:content,:image).merge(user_id: current_user.id)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,5 +3,9 @@ class Message < ApplicationRecord
   belongs_to :room
   has_one_attached :image
 
-  validates :content, presence: true
+  validates :content, presence: true, unless: :was_attached?
+
+  def was_attached?
+    self.image.attached?
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
-  has_many_attached :image
+  has_one_attached :image
 
   validates :content, presence: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
+  has_many_attached :image
 
   validates :content, presence: true
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -11,5 +11,6 @@
     <div class="message-content">
       <%= message.content%>
     </div>
+    <%= image_tag message.image.variant(resize: '500x500'), class: 'message-image' if message.image.attached? %>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -11,6 +11,6 @@
     <div class="message-content">
       <%= message.content%>
     </div>
-    <%= image_tag message.image.variant(resize: '500x500'), class: 'message-image' if message.image.attached? %>
+    <%= image_tag message.image.variant(resize: '400x400'), class: 'message-image' if message.image.attached? %>
   </div>
 </div>

--- a/db/migrate/20200828092030_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200828092030_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_061257) do
+ActiveRecord::Schema.define(version: 2020_08_28_092030) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -53,6 +74,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_061257) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"


### PR DESCRIPTION
### What
- ActiveStorageを使用し、画像を投稿できるように実装
- 画像サイズも一定サイズに調整
- 画像のみのmessageでも投稿できるように仕様変更

### Why
- 画像を投稿できると、トークの幅が広がる為。