### PR TITLE
メッセージ削除機能の実装

### DIFF
--- a/app/assets/stylesheets/messages.css
+++ b/app/assets/stylesheets/messages.css
@@ -97,6 +97,7 @@
   border-bottom: 7px solid #38aef0;
   border-radius: 10px;
   width: 500px;
+  position: relative;
 }
 
 .upper-message {
@@ -176,4 +177,22 @@ div[data-check="true"] {
   border: solid 2px #c6e4ff;
   border-radius: 10px;
   border-bottom: solid 6px #aac5ed;
+}
+
+.delete-btn {
+  width: 50px;
+  height: 25px;
+  text-decoration: none;
+  border-radius: 10px;
+  color: white;
+  background-color: #62879e;
+  text-align: center;
+  position: absolute;
+  top: 50px;
+  left: 400px;
+}
+
+.delete-btn a {
+  color: white;
+  text-decoration: none;
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,6 +16,14 @@ class MessagesController < ApplicationController
     end
   end
 
+  def destroy
+    @room = Room.find(params[:room_id])
+    message = @room.messages.find(params[:id])
+    if message.destroy
+      redirect_to room_messages_path(@room)
+    end
+  end
+
   def checked
     message = Message.find(params[:id])
     if message.checked

--- a/app/views/messages/_main_chat.html.erb
+++ b/app/views/messages/_main_chat.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="right-header">
     <div class="header-button">
-      <%= link_to "トークの終了", root_path %>
+      <%= link_to "トーク終了", root_path %>
     </div>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -13,4 +13,7 @@
     </div>
     <%= image_tag message.image.variant(resize: '400x400'), class: 'message-image' if message.image.attached? %>
   </div>
+  <div class="delete-btn">
+    <%= link_to "削除", room_message_path(@room, message.id), method: :delete %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root to: "rooms#index"
   resources :users, only: [:edit, :update]
   resources :rooms, only: [:new, :create, :edit, :update, :destroy] do
-    resources :messages, only: [:index, :create]
+    resources :messages, only: [:index, :create, :destroy]
   end
   get 'messages/:id', to: 'messages#checked'
 end


### PR DESCRIPTION
### What
- メッセージ削除後に、そのままトークルームに遷移する。
- 削除ボタンをメッセージ内に実装

### Why
- ユーザーが間違えて投稿した内容を削除できるようにするため。